### PR TITLE
Refactor nancy

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,5 +1,6 @@
 class ReviewsController <ApplicationController
   def index
+    binding.pry
     if params[:item_id]
       @item = Item.find(params[:item_id])
       @reviews = @item.reviews
@@ -29,9 +30,9 @@ class ReviewsController <ApplicationController
   end
 
   def destroy
-    review = Review.find(params[:id])
-    review.destroy
-    redirect_to "/reviews"
+    @review = Review.find(params[:id])
+    @review.destroy
+    redirect_to "/items/#{@review.item.id}"
   end
 
   private

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,20 +1,37 @@
 class ReviewsController <ApplicationController
+  def index
+    if params[:item_id]
+      @item = Item.find(params[:item_id])
+      @reviews = @item.reviews
+    else
+      @reviews = Review.all
+    end
+  end
 
   def new
-    #binding.pry
-    @item = Item.find(params[:id])
+    @item = Item.find(params[:item_id])
+  end
+
+  def show
+    @review = Review.find(params[:id])
   end
 
   def create
-    @item = Item.find(params[:id])
+    @item = Item.find(params[:item_id])
     review = @item.reviews.create(review_params)
     if review.save
       flash[:success] = "You have successfully posted a review"
       redirect_to "/items/#{@item.id}"
     else
       flash[:alert] = "You have not completed the form. Please complete all three sections to post a review."
-      redirect_to "/items/#{@item.id}/review/new"
+      redirect_to "/items/#{@item.id}/reviews/new"
     end
+  end
+
+  def destroy
+    review = Review.find(params[:id])
+    review.destroy
+    redirect_to "/reviews"
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item <ApplicationRecord
   belongs_to :merchant
-  has_many :reviews
+  has_many :reviews, dependent: :destroy
 
   validates_presence_of :name,
                         :description,

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -20,39 +20,4 @@
   </section>
 </center>
 
-<div>
-  <section id='item-<%= @item.id %>-review-stats'>
-    <p>Average Rating: <%= @item.reviews.average_review_rating %> </p>
-  </section>
-
-  <section id='item-<%= @item.id %>-top-3-reviews'>
-    <p>Top 3</p>
-    <% @item.reviews.top_three_reviews.each do |title, rating| %>
-      <div>
-        <span><%= title %></span>
-        <span><%= rating %></span>
-      </div>
-    <% end %>
-  </section>
-
-  <section id='item-<%= @item.id %>-bottom-3-reviews'>
-    <p>Top 3</p>
-    <% @item.reviews.bottom_three_reviews.each do |title, rating| %>
-      <div>
-        <span><%= title %></span>
-        <span><%= rating %></span>
-      </div>
-    <% end %>
-  </section>
-</div>
-
-<div>
-  <div> <%= link_to "add new review", "/items/#{@item.id}/review/new" %></div>
-  <p>Reviews: <% @item.reviews.each do |review| %> </p>
-    <section id= 'review-<%=review.id%>'>
-      <p><%= review.title %></p>
-      <p><%= review.content %></p>
-      <p>Rating: <%= review.rating %></p>
-    </section>
-  <% end %>
-</div>
+<%= render "reviews/index" %>

--- a/app/views/reviews/_index.html.erb
+++ b/app/views/reviews/_index.html.erb
@@ -1,0 +1,39 @@
+<div>
+  <div>
+    <section id='item-<%= @item.id %>-review-stats'>
+      <p>Average Rating: <%= @item.reviews.average_review_rating %> </p>
+    </section>
+
+    <section id='item-<%= @item.id %>-top-3-reviews'>
+      <p>Top 3</p>
+      <% @item.reviews.top_three_reviews.each do |title, rating| %>
+        <div>
+          <span><%= title %></span>
+          <span><%= rating %></span>
+        </div>
+      <% end %>
+    </section>
+
+    <section id='item-<%= @item.id %>-bottom-3-reviews'>
+      <p>Bottom 3</p>
+      <% @item.reviews.bottom_three_reviews.each do |title, rating| %>
+        <div>
+          <span><%= title %></span>
+          <span><%= rating %></span>
+        </div>
+      <% end %>
+    </section>
+  </div>
+
+  <div>
+    <div> <%= link_to "add new review", "/items/#{@item.id}/reviews/new" %></div>
+    <p>Reviews: <% @item.reviews.each do |review| %> </p>
+      <section id= 'review-<%=review.id%>'>
+        <p><%= review.title %></p>
+        <p><%= review.content %></p>
+        <p>Rating: <%= review.rating %></p>
+      </section>
+      <p id='delete-review-<%=review.id%>'><%= link_to "Delete Review", "/reviews/#{review.id}", method: :delete, data: { confirm: 'Are you sure?' } %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -1,0 +1,41 @@
+<div>
+  <div>
+    <section id='item-<%= @item.id %>-review-stats'>
+      <p>Average Rating: <%= @item.reviews.average_review_rating %> </p>
+    </section>
+
+    <section id='item-<%= @item.id %>-top-3-reviews'>
+      <p>Top 3</p>
+      <% @item.reviews.top_three_reviews.each do |title, rating| %>
+        <div>
+          <span><%= title %></span>
+          <span><%= rating %></span>
+        </div>
+      <% end %>
+    </section>
+
+    <section id='item-<%= @item.id %>-bottom-3-reviews'>
+      <p>Bottom 3</p>
+      <% @item.reviews.bottom_three_reviews.each do |title, rating| %>
+        <div>
+          <span><%= title %></span>
+          <span><%= rating %></span>
+        </div>
+      <% end %>
+    </section>
+  </div>
+
+  <div> <%= link_to "add new review", "/items/#{@item.id}/reviews/new" %></div>
+
+  <div>
+    <h2>Reviews</h2>
+    <% @item.reviews.each do |review| %>
+      <section id= 'review-<%=review.id%>'>
+        <p><%= review.title %></p>
+        <p><%= review.content %></p>
+        <p>Rating: <%= review.rating %></p>
+      </section>
+      <p id="delete-review-<%= review.id %>"><%= link_to "Delete Review", "/reviews/#{review.id}", method: :delete, data: { confirm: 'Are you sure?' } %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -1,7 +1,7 @@
 <h1> Add New Review </h1>
 
 <center>
-  <%= form_tag "/items/#{@item.id}", method: :post do %>
+  <%= form_tag "/items/#{@item.id}/reviews", method: :post do %>
     <%= text_field_tag :title %>
 
     <%= text_field_tag :content %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,0 +1,9 @@
+  <div>
+    <h2>Review</h2>
+      <section id= 'review-<%= @review.id %>'>
+        <p><%= @review.title %></p>
+        <p><%= @review.content %></p>
+        <p>Rating: <%= @review.rating %></p>
+      </section>
+      <p id="delete-review-<%= @review.id %>"><%= link_to "Delete Review", "/reviews/#{@review.id}", method: :delete, data: { confirm: 'Are you sure?' } %></p>
+  </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,6 @@ Rails.application.routes.draw do
   delete "/items/:id", to: "items#destroy"
 
   get "/items/:item_id/reviews", to: "reviews#index"
-  get "/reviews", to: "reviews#index"
   get "/reviews/:id", to: "reviews#show"
   get "/items/:item_id/reviews/new", to: "reviews#new"
   post "/items/:item_id/reviews", to: "reviews#create"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,10 @@ Rails.application.routes.draw do
   post "/merchants/:merchant_id/items", to: "items#create"
   delete "/items/:id", to: "items#destroy"
 
-  get "/items/:id/review/new", to: "reviews#new"
-  post "/items/:id", to: "reviews#create"
+  get "/items/:item_id/reviews", to: "reviews#index"
+  get "/reviews", to: "reviews#index"
+  get "/reviews/:id", to: "reviews#show"
+  get "/items/:item_id/reviews/new", to: "reviews#new"
+  post "/items/:item_id/reviews", to: "reviews#create"
+  delete "/reviews/:id", to: "reviews#destroy"
 end

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -11,13 +11,9 @@ RSpec.describe 'item show page', type: :feature do
     @dog_bone = @brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
     @active_items = [@tire, @pull_toy]
     @inactive_items = [@dog_bone]
+
     @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
     @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-
-    @good_review = @chain.reviews.create(title: "I like this product", content: "This is a great product. I will buy it again soon.", rating: 5)
-    @average_review = @chain.reviews.create(title: "So-so product", content: "This is okay.", rating: 3)
-    @negative_review = @chain.reviews.create(title: "I don't like this product", content: "This is not a great product. I will not buy it again soon.", rating: 2)
-    @terrible_review = @chain.reviews.create(title: "I hate it", content: "Never buy it again.", rating: 1)
   end
 
   it 'shows item info' do
@@ -32,85 +28,5 @@ RSpec.describe 'item show page', type: :feature do
     expect(page).to have_content("Inventory: #{@chain.inventory}")
     expect(page).to have_content("Sold by: #{@bike_shop.name}")
     expect(page).to have_css("img[src*='#{@chain.image}']")
-  end
-
-  it 'shows reviews for an item' do
-
-    visit "items/#{@chain.id}"
-
-    within "#review-#{@good_review.id}" do
-      expect(page).to have_content(@good_review.title)
-      expect(page).to have_content(@good_review.content)
-      expect(page).to have_content(@good_review.rating)
-    end
-  end
-
-  it 'shows link to add a new review for item and shows flash messages' do
-    visit "/items/#{@chain.id}"
-    click_link "add new review"
-
-    expect(current_path).to eq("/items/#{@chain.id}/review/new")
-
-    title = "So-so product"
-    content = "This product was very, very average"
-    rating = 3
-
-    fill_in :title, with: title
-    fill_in :content, with: content
-    fill_in :rating, with: rating
-
-    click_button "Post Review"
-
-    expect(current_path).to eq("/items/#{@chain.id}")
-    expect(page).to have_content("You have successfully posted a review")
-
-    within "#review-#{Review.last.id}" do
-      expect(page).to have_content(title)
-      expect(page).to have_content(content)
-      expect(page).to have_content("Rating: #{rating}")
-    end
-  end
-
-  it 'shows alert flash messages when form is not completely filled' do
-    visit "/items/#{@chain.id}"
-    click_link "add new review"
-
-    expect(current_path).to eq("/items/#{@chain.id}/review/new")
-
-    title = "So-so product"
-
-    fill_in :title, with: title
-
-    click_button "Post Review"
-
-    expect(current_path).to eq("/items/#{@chain.id}/review/new")
-    expect(page).to have_content("You have not completed the form. Please complete all three sections to post a review.")
-  end
-
-  it 'shows review stats' do
-    visit "/items/#{@chain.id}"
-
-    within "#item-#{@chain.id}-review-stats" do
-      expect(page).to have_content("Average Rating: #{@chain.reviews.average(:rating)}")
-    end
-
-    within "#item-#{@chain.id}-top-3-reviews" do
-      top_three_title_rating = @chain.reviews.order(:rating).reverse[0..2].pluck(:title, :rating)
-
-      expect(page).to have_content("#{top_three_title_rating[0][0]}")
-      expect(page).to have_content("#{top_three_title_rating[0][1]}")
-      expect(page).to have_content("#{top_three_title_rating[1][0]}")
-      expect(page).to have_content("#{top_three_title_rating[1][1]}")
-    end
-
-    within "#item-#{@chain.id}-bottom-3-reviews" do
-      bottom_three_title_rating = @chain.reviews.order(:rating)[0..2].pluck(:title, :rating)
-
-      expect(page).to have_content("#{bottom_three_title_rating[0][0]}")
-      expect(page).to have_content("#{bottom_three_title_rating[0][1]}")
-      expect(page).to have_content("#{bottom_three_title_rating[1][0]}")
-      expect(page).to have_content("#{bottom_three_title_rating[1][1]}")
-    end
-
   end
 end

--- a/spec/features/reviews/delete_spec.rb
+++ b/spec/features/reviews/delete_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "Reviews Index" do
+  describe "When I visit the items show page" do
+    before(:each) do
+      @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      @good_review = @chain.reviews.create(title: "I like this product", content: "This is a great product. I will buy it again soon.", rating: 5)
+    end
+
+    it "shows a link next to each review to delete the review" do
+      visit "/reviews/#{@good_review.id}"
+
+      expect(page).to have_link("Delete Review")
+      click_on "Delete Review"
+
+      expect(current_path).to eq("/reviews")
+      expect(page).to_not have_css("#review-#{@good_review.id}")
+    end
+
+  end
+end

--- a/spec/features/reviews/delete_spec.rb
+++ b/spec/features/reviews/delete_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Reviews Index" do
       expect(page).to have_link("Delete Review")
       click_on "Delete Review"
 
-      expect(current_path).to eq("/reviews")
+      expect(current_path).to eq("/items/#{@chain.id}")
       expect(page).to_not have_css("#review-#{@good_review.id}")
     end
 

--- a/spec/features/reviews/index_spec.rb
+++ b/spec/features/reviews/index_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "Reviews Index" do
+  describe "When I visit the items show page" do
+    before(:each) do
+      @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      @good_review = @chain.reviews.create(title: "I like this product", content: "This is a great product. I will buy it again soon.", rating: 5)
+      @average_review = @chain.reviews.create(title: "So-so product", content: "This is okay.", rating: 3)
+      @negative_review = @chain.reviews.create(title: "I don't like this product", content: "This is not a great product. I will not buy it again soon.", rating: 2)
+      @terrible_review = @chain.reviews.create(title: "I hate it", content: "Never buy it again.", rating: 1)
+    end
+
+    it 'shows reviews for an item' do
+
+      visit "items/#{@chain.id}"
+
+      within "#review-#{@good_review.id}" do
+        expect(page).to have_content(@good_review.title)
+        expect(page).to have_content(@good_review.content)
+        expect(page).to have_content(@good_review.rating)
+      end
+    end
+  end
+end

--- a/spec/features/reviews/new_spec.rb
+++ b/spec/features/reviews/new_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe "Reviews Index" do
+  describe "When I visit the items show page" do
+    before(:each) do
+      @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      @good_review = @chain.reviews.create(title: "I like this product", content: "This is a great product. I will buy it again soon.", rating: 5)
+      @average_review = @chain.reviews.create(title: "So-so product", content: "This is okay.", rating: 3)
+      @negative_review = @chain.reviews.create(title: "I don't like this product", content: "This is not a great product. I will not buy it again soon.", rating: 2)
+      @terrible_review = @chain.reviews.create(title: "I hate it", content: "Never buy it again.", rating: 1)
+    end
+
+    it 'shows link to add a new review for item and shows flash messages' do
+      visit "/items/#{@chain.id}"
+      click_link "add new review"
+
+      expect(current_path).to eq("/items/#{@chain.id}/reviews/new")
+
+      title = "So-so product"
+      content = "This product was very, very average"
+      rating = 3
+
+      fill_in :title, with: title
+      fill_in :content, with: content
+      fill_in :rating, with: rating
+
+      click_button "Post Review"
+
+      expect(current_path).to eq("/items/#{@chain.id}")
+      expect(page).to have_content("You have successfully posted a review")
+
+      within "#review-#{Review.last.id}" do
+        expect(page).to have_content(title)
+        expect(page).to have_content(content)
+        expect(page).to have_content("Rating: #{rating}")
+      end
+    end
+  end
+end

--- a/spec/features/reviews/show_spec.rb
+++ b/spec/features/reviews/show_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe "Reviews Index" do
+  describe "When I visit the items show page" do
+    before(:each) do
+      @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      @good_review = @chain.reviews.create(title: "I like this product", content: "This is a great product. I will buy it again soon.", rating: 5)
+      @average_review = @chain.reviews.create(title: "So-so product", content: "This is okay.", rating: 3)
+      @negative_review = @chain.reviews.create(title: "I don't like this product", content: "This is not a great product. I will not buy it again soon.", rating: 2)
+      @terrible_review = @chain.reviews.create(title: "I hate it", content: "Never buy it again.", rating: 1)
+    end
+
+    it 'shows alert flash messages when form is not completely filled' do
+      visit "/items/#{@chain.id}"
+      click_link "add new review"
+
+      expect(current_path).to eq("/items/#{@chain.id}/reviews/new")
+
+      title = "So-so product"
+
+      fill_in :title, with: title
+
+      click_button "Post Review"
+
+      expect(current_path).to eq("/items/#{@chain.id}/reviews/new")
+      expect(page).to have_content("You have not completed the form. Please complete all three sections to post a review.")
+    end
+
+    it 'shows review stats' do
+      visit "/items/#{@chain.id}"
+
+      within "#item-#{@chain.id}-review-stats" do
+        expect(page).to have_content("Average Rating: #{@chain.reviews.average(:rating)}")
+      end
+
+      within "#item-#{@chain.id}-top-3-reviews" do
+        top_three_title_rating = @chain.reviews.order(:rating).reverse[0..2].pluck(:title, :rating)
+
+        expect(page).to have_content("#{top_three_title_rating[0][0]}")
+        expect(page).to have_content("#{top_three_title_rating[0][1]}")
+        expect(page).to have_content("#{top_three_title_rating[1][0]}")
+        expect(page).to have_content("#{top_three_title_rating[1][1]}")
+      end
+
+      within "#item-#{@chain.id}-bottom-3-reviews" do
+        bottom_three_title_rating = @chain.reviews.order(:rating)[0..2].pluck(:title, :rating)
+
+        expect(page).to have_content("#{bottom_three_title_rating[0][0]}")
+        expect(page).to have_content("#{bottom_three_title_rating[0][1]}")
+        expect(page).to have_content("#{bottom_three_title_rating[1][0]}")
+        expect(page).to have_content("#{bottom_three_title_rating[1][1]}")
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'simplecov'
+SimpleCov.start 
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)


### PR DESCRIPTION
While trying to implement delete_review functionality, I encountered a `ForeignKeyViolation` error; initially, we started out with reviews not having its own MVC framework because we thought that review section should appear on bottom half of the item show page. However, in that case, implementing a delete action would destroy a given item, not the reviews belonging to the item.

To solve this problem, I had to create a separate `reviews` directory with relevant routes, reviews_controller actions, and view pages. To have the reviews section appear on item show page, a partial tag was included.